### PR TITLE
Remove section on finite radius and focus on extrapolation

### DIFF
--- a/Examples/waveform_tutorial.ipynb
+++ b/Examples/waveform_tutorial.ipynb
@@ -6,18 +6,45 @@
    "source": [
     "# Waveform Tutorial\n",
     "\n",
-    "March 6, 2019\n",
+    "March 6, 2019    \n",
+    "Edited May 13, 2019\n",
+    "\n",
+    "----\n",
+    "\n",
+    "## Extracting Waveforms\n",
+    "\n",
+    "When a certain waveform quantity (e.g. $h$, $\\Psi_4$, etc.) is computed in the Spectral Einstein Code (SpEC), it is decomposed in terms of the spin-weighted spherical harmonics (SWSHs) ${}_{s}Y_{\\ell}^{m}$ with the appropriate spin-weight $s$ for the quantity. For example,\n",
+    "\n",
+    "$$ h(r,t,\\theta,\\phi) = \\sum_{\\ell=2} \\sum_{m=-\\ell}^{\\ell} h^{(\\ell,m)}(r,t)\\; {}_{-2}Y_{\\ell}^{m}(\\theta,\\phi) \\hspace{3cm} (1)$$\n",
+    "\n",
+    "The mode weights of this decomposition can be extracted from the simulation and can be used with the equation above to get $h(r,t,\\theta,\\phi)$. Since the strain $h$ and the Weyl scalar $\\Psi_4$ fall off predominantly as $r^{-1}$, we multiply the values by the extraction radius before writing to disk, which is why the file names are `rh*.h5` and `rPsi4*.h5`. So in our example, we would write $rh^{(\\ell,m)}(r,t)$ to disk as an HDF5 file for all timesteps $t$ in our simulation and for the specific values of the radius $r$ at which we measured this quantity.\n",
+    "\n",
+    "\n",
+    "## Extrapolation\n",
+    "\n",
+    "We expect that the waveform at asymptotic null infinity has the following fall-off behavior:\n",
+    "$$ \\lim_{r\\rightarrow\\infty} h \\sim \\frac{1}{r} \\hspace{3cm} (2)$$\n",
+    "However, it is evident that our waveforms extracted at finite radii have higher order terms (e.g. $r^{-2}$, $r^{-3}$, etc.) that should not be present in a waveform observed at null infinity. We therefore apply an extrapolation procedure to our finite radius waveforms in order to have a more reasonable final waveform. We also apply a correction for center-of-mass drift in the simulation. To allow for comparison, we provide the following data for each simulation:\n",
+    "\n",
+    "* `*_Asymptotic_GeometricUnits_CoM.h5` -- waveforms that have been extrapolated and center-of-mass corrected\n",
+    "* `*_Asymptotic_GeometricUnits.h5` -- waveforms that have been extrapolated\n",
+    "* `*_FiniteRadii_CodeUnits.h5` -- raw finite radius waveforms\n",
+    "\n",
+    "In our catalog as of March 6, 2019, **only** the waveforms ending with `*_Asymptotic_GeometricUnits_CoM.h5` should be used for analysis. If more corrections have been added to the waveforms since then, please use the more up-to-date versions and update this tutorial. These waveforms also inlcude a factor of $M$ as specified in the name of the file in order to render the data dimensionless ($G=c=1$):\n",
+    "$$ r M^{-1} h \\hspace{1cm} r M \\Psi_4 $$\n",
+    "\n",
+    "For a discussion of the extrapolation procedure, please see:\n",
+    "[M. Boyle and A. H. Mroué, *Phys. Rev.* **D80**, 124045 (2009)](https://arxiv.org/abs/0905.3177)  \n",
+    "For a discussion of other corrections applied to the waveforms, please see:\n",
+    "[M. Boyle, *Phys. Rev.* **D93**, 084031 (2016)](https://arxiv.org/abs/1509.00862)\n",
+    "\n",
+    "Note that the finite radius waveforms use coordinate radius values and the extrapolated waveforms use areal radius:\n",
+    "$$ r = \\sqrt{\\frac{1}{4\\pi} \\int_{S^2} |g|\\, d\\Omega}$$\n",
+    "where $|g|$ is the determinant of the metric, and the surface $S^2$ is the surface of constant coordinate radius where the values of the waveform computed in the simulation.\n",
     "\n",
     "---\n",
-    "## Finite Radii Waveforms\n",
     "\n",
-    "SpEC datafiles with names `*_FiniteRadii_CodeUnits.h5` hold data extracted at finite radii. When a certain waveform quantity (e.g. $h$, $\\Psi_4$, etc.) is computed in SpEC, it is decomposed in terms of the spin-weighted spherical harmonics (SWSHs) ${}_{s}Y_{\\ell}^{m}$ with appropriate spin-weight $s$ for the quantity. For example,\n",
-    "\n",
-    "$$ h(r,t,\\theta,\\phi) = \\sum_{\\ell} \\sum_{m=-\\ell}^{\\ell} h^{(\\ell,m)}(r,t)\\; {}_{-2}Y_{\\ell}^{m}(\\theta,\\phi) \\hspace{3cm} (1)$$\n",
-    "\n",
-    "The mode weights of this decomposition are written to disk as an HDF5 file. So in our example, we would write $h^{(\\ell,m)}(r,t)$ to disk for all timesteps $t$ in our simulation and for the specific values of the radius $r$ at which we measured this quantity. Since the strain $h$ and the Weyl scalar $\\Psi_4$ fall off predominantly as $r^{-1}$, we multiply the values by the extraction radius before writing to disk, which is why the file names are `rh*.h5` and `rPsi4*.h5`. For finite radius waveforms, all the radius values $r$ are the coordinate radius values. For extrapolation we use the areal radius; see the Extrapolated Waveforms section below for more details.\n",
-    "\n",
-    "The Python module [h5py](https://www.h5py.org/]) provides convenient tools for working with HDF5 files, which contain an internal directory structure that nicely organizes the data. Let's start by opening up one of these `*_FiniteRadii_CodeUnits.h5` files. To follow this notebook, click [here](https://zenodo.org/record/1215624/files/SXS:BBH:1355/Lev1/rh_FiniteRadii_CodeUnits.h5?download=1) to download a short waveform of the gravitational radiation $rh$ from simulation SXS:BBH:1355 in our catalog. This waveform has the lowest resolution data (Lev1) for an eccentric equal-mass non-spinning binary black hole simulation. "
+    "The Python module [h5py](https://www.h5py.org/]) provides convenient tools for working with HDF5 files, which contain an internal directory structure that nicely organizes the data. Let's start by opening up an `rh_Asymptotic_GeometricUnits_CoM.h5` file. To follow this notebook, click [here](https://zenodo.org/record/1215624/files/SXS:BBH:1355/Lev1/rhOverM_Asymptotic_GeometricUnits_CoM.h5?download=1) to download a short waveform of the gravitational radiation $rh$ from simulation SXS:BBH:1355 in our catalog. This waveform has the lowest resolution data (Lev1) for an eccentric equal-mass non-spinning binary black hole simulation. "
    ]
   },
   {
@@ -31,7 +58,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "# Please uncomment the line below and fill in the correct path\n",
-    "rh_file = # /path/to/rh_FiniteRadii_CodeUnits.h5\"\n",
+    "rh_file = # \"/path/to/rhOverM_Asymptotic_GeometricUnits_CoM.h5\"\n",
     "\n",
     "# Open the HDF5 file in read-only mode:\n",
     "rh_data = h5py.File(rh_file,'r')"
@@ -52,7 +79,7 @@
     "\n",
     "\n",
     "\n",
-    "We navigate through the HDF5 directory structure by specifying the path as a key to `rh_data`. HDF5 directories are known as \"groups\", so the root group is:\n",
+    "We navigate through the HDF5 directory structure by specifying the path as a key to `rh_data`, which is essentially a dictionary. HDF5 directories are known as \"groups\", so the root group is:\n",
     "\n",
     "`rh_data['/']`\n",
     "\n",
@@ -81,7 +108,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We should find groups named `R####.dir` where the four-digit number `####` is the radius $r$ (in simulation coordinate units) at which we computed $h$. We want to look at the largest radius that we can in order to avoid near-zone effects. The largest radius is at $545 M$ in group `R0545.dir`. Let's now see what we have in this group."
+    "We should find three groups called `Extrapolated_N*.dir` that holds waveforms extrapolated to different orders, and one group called `OutermostExtraction.dir` that holds waveforms extracted from the outermost extraction radius in the simulation. Accuracy of extrapolation to future null infinity can be assessed by comparing different extrapolation orders. The 'best' extrapolation order to use depends on the simulation and what the waveform is being used for. Higher order tends to do better in the inspiral but worse in the ringdown; it is likely that the `OutermostExtraction` data is better than extrapolated data during ringdown.\n",
+    "\n",
+    "Let's now see what we have in one of these groups."
    ]
   },
   {
@@ -90,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for group in sorted(rh_data['R0545.dir']): \n",
+    "for group in sorted(rh_data['Extrapolated_N4.dir']): \n",
     "    print(group)"
    ]
   },
@@ -98,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now see that this group is full of datasets. The first few datasets are needed for the extrapolation procedure in [GWFrames](https://github.com/moble/GWFrames), and the rest are files labeled `Y_l*_m*.dat`. These are the datasets that hold the mode weights for $rh$. The spin-weight of the spherical harmonic decomposition is assumed! In other words, these are ***not*** the mode weights for $Y_{\\ell}^{m}$ but for ${}_{-2}Y_{\\ell}^{m}$. \n",
+    "We now see that this group is full of datasets. There is a file `History.txt` that records any changes to the data in post-processing (i.e. extrapolation, correction for center-of-mass drift, etc.), and the rest are datasets labelled `Y_l*_m*.dat`. These are the datasets that hold the complex mode weights for $rh$. The spin-weight of the spherical harmonic decomposition is assumed! When computing $h$ from the mode weights, be sure you use the spin-weighted spherical harmonics and not just the usual (spin-weight = 0) spherical harmonics. In other words, these are ***not*** the mode weights for $Y_{\\ell}^{m}$ but for ${}_{-2}Y_{\\ell}^{m}$.\n",
     "\n",
     "The dominant modes for the strain are the $(\\ell=2,m=\\pm 2)$ modes so let's take a look at one of those datasets."
    ]
@@ -109,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rh_data['R0545.dir/Y_l2_m2.dat'].shape\n",
+    "rh_data['Extrapolated_N4.dir/Y_l2_m2.dat'].shape\n",
     "\n",
     "# For the m=-2 mode:\n",
     "# rh_data['R0545.dir/Y_l2_m-2.dat'].shape"
@@ -119,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first column of the dataset is the time, the second column is the real part of $rh^{(\\ell,m)}$, and the third column is the imaginary part of $rh^{(\\ell,m)}$. We see from above that we have 12492 timesteps in this dataset. Let's build a 1D array holding the complex waveform instead of having to access different columns of the HDF5 file:"
+    "The first column of the dataset is the retarted time, the second column is the real part of $rh^{(\\ell,m)}$, and the third column is the imaginary part of $rh^{(\\ell,m)}$. We see from above that we have 12855 timesteps in this dataset. For convenience, let's build a 1D array holding the complex waveform instead of having to access different columns of the HDF5 file."
    ]
   },
   {
@@ -128,36 +157,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's take the l=m=2 mode\n",
+    "# Let's take the l=m=2 mode \n",
+    "idx = 'Extrapolated_N4.dir/Y_l2_m2.dat'\n",
+    "ret_time = rh_data[idx][:,0]\n",
+    "rh = rh_data[idx][:,1] + 1j*rh_data[idx][:,2]\n",
     "\n",
-    "idx = 'R0545.dir/Y_l2_m2.dat'\n",
-    "rh = rh_data[idx][:,1] + 1j*rh_data[idx][:,2] \n",
-    "\n",
-    "time = rh_data['R0545.dir/Y_l2_m2.dat'][:,0]\n",
-    "ret_time = time - 545 # Define retarded time"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can plot the waveform:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# To plot the waveform interactively, uncomment the following line:\n",
     "# %matplotlib qt\n",
-    "\n",
     "plt.plot(ret_time, np.real(rh), label='Real')\n",
     "plt.plot(ret_time, np.imag(rh), label='Imag')\n",
     "plt.plot(ret_time,  np.abs(rh), label='Abs')\n",
-    "plt.title('Finite Radius Waveform, R=545M')\n",
-    "plt.xlabel('$(t - r)/M$')\n",
+    "plt.title('Extrapolated Waveform, N=4')\n",
+    "plt.xlabel('$(t_{corr} - r^{*})/M$')\n",
     "plt.ylabel('$rh^{(2,2)}$')\n",
     "plt.legend()\n",
     "plt.show()"
@@ -167,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Often, the plot above may be colloquially referred to as a plot of $rh$, but remember that it is actually a plot of just the $\\ell=m=2$ mode weight of $rh$!\n",
+    "Often, the plot above is colloquially referred to as a plot of $rh$, but remember that it is *actually* a plot of just the $\\ell=m=2$ mode weight of $rh$!\n",
     "\n",
     "It might also be useful to plot $rh^{(\\ell,m)}$ for not just the leading order $(2,2)$ mode but for other modes as well."
    ]
@@ -175,43 +186,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for lm in [(2,2),(4,4),(3,2),(6,6),(5,4),(8,8)]:\n",
     "    l = str(lm[0])\n",
     "    m = str(lm[1])\n",
-    "    idx = 'R0545.dir/Y_l'+l+'_m'+m+'.dat'\n",
+    "    idx = 'Extrapolated_N4.dir/Y_l'+l+'_m'+m+'.dat'\n",
     "    ret_time = rh_data[idx][:,0] - 545\n",
     "    rh = rh_data[idx][:,1] + 1j*rh_data[idx][:,2] \n",
     "    \n",
     "    plt.semilogy(ret_time, np.abs(rh), label='('+l+','+m+')')\n",
     "    \n",
-    "plt.title('Finite Radius Waveform, R=545M')\n",
-    "plt.xlabel('$(t - r)/M$')\n",
+    "plt.title('Extrapolated Waveform, N=4')\n",
+    "plt.xlabel('$(t_{corr} - r^{*})/M$')\n",
     "plt.ylabel('$rh^{(\\ell,m)}$')\n",
-    "plt.legend()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "radii = [int(radius_str[1:5]) for radius_str in sorted(rh_data) if radius_str.startswith('R')]\n",
-    "for R in radii[::2]:\n",
-    "    idx = 'R'+str(R).zfill(4)+'.dir/Y_l2_m2.dat'\n",
-    "    ret_time = rh_data[idx][:,0] - R\n",
-    "    rh = rh_data[idx][:,1] + 1j*rh_data[idx][:,2] \n",
-    "    \n",
-    "    plt.plot(ret_time, np.abs(rh), label='R='+str(R)+' M')\n",
-    "\n",
-    "plt.xlim(2600,3300)\n",
-    "plt.title('Finite Radius Waveform')\n",
-    "plt.xlabel('$(t - r)/M$')\n",
-    "plt.ylabel('$rh^{(2,2)}$')\n",
     "plt.legend()\n",
     "plt.show()"
    ]
@@ -232,103 +223,14 @@
    "source": [
     "---\n",
     "\n",
-    "## Extrapolated Waveforms\n",
-    "\n",
-    "We expect that the waveform at asymptotic null infinity has the following fall-off behavior:\n",
-    "$$ \\lim_{r\\rightarrow\\infty} h \\sim \\frac{1}{r} \\hspace{3cm} (2)$$\n",
-    "However, it is evident that our finite radius waveforms have higher order terms (e.g. $r^{-2}$, $r^{-3}$, etc.) that should not be present in a waveform observed at null infinity. We therefore apply an extrapolation procedure and a center-of-mass correction to our finite radius waveforms in order to have a more reasonable final waveform. In our catalog as of March 6, 2019, only the waveforms ending with `*_Asymptotic_GeometricUnits_CoM.h5` should be used for analysis. If more corrections have been added to the waveforms since then, please use the more up-to-date versions and update this tutorial. These waveforms also inlcude a factor of $M$ as specified in the name of the file in order to render the data dimensionless ($G=c=1$):\n",
-    "$$ r M^{-1} h \\hspace{1cm} r M \\Psi_4 $$\n",
-    "\n",
-    "For a discussion of the extrapolation procedure, please see:\n",
-    "[M. Boyle and A. H. Mroué, *Phys. Rev.* **D80**, 124045 (2009)](https://arxiv.org/abs/0905.3177)  \n",
-    "For a discussion of other corrections applied to the waveforms, please see:\n",
-    "[M. Boyle, *Phys. Rev.* **D93**, 084031 (2016)](https://arxiv.org/abs/1509.00862)\n",
-    "\n",
-    "To follow this part of the notebook, click [here](https://zenodo.org/record/1215624/files/SXS:BBH:1355/Lev1/rhOverM_Asymptotic_GeometricUnits_CoM.h5?download=1) to download an extrapolated waveform. This waveform is the extrapolated version of the finite radius waveform we were looking at above.\n",
-    "\n",
-    "Note that the finite radius waveforms use coordinate radius values and the extrapolated waveforms use areal radius:\n",
-    "$$ r = \\sqrt{\\frac{1}{4\\pi} \\int_{S^2} |g|\\, d\\Omega}$$\n",
-    "where $|g|$ is the determinant of the metric, and the surface $S^2$ is the surface of constant coordinate radius where the values of the waveform computed in the simulation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Please uncomment the line below and fill in the correct path\n",
-    "rh_file = # \"/path/to/rhOverM_Asymptotic_GeometricUnits_CoM.h5\"\n",
-    "\n",
-    "# Open the HDF5 file in read-only mode:\n",
-    "rh_data = h5py.File(rh_file,'r')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's see what groups we have in the root group:\n",
-    "for group in sorted(rh_data): \n",
-    "    print(group)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for group in sorted(rh_data['Extrapolated_N4.dir']): \n",
-    "    print(group)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's take the l=m=2 mode again\n",
-    "idx = 'Extrapolated_N4.dir/Y_l2_m2.dat'\n",
-    "ret_time = rh_data[idx][:,0]\n",
-    "rh = rh_data[idx][:,1] + 1j*rh_data[idx][:,2]\n",
-    "\n",
-    "plt.plot(ret_time, np.real(rh), label='Real')\n",
-    "plt.plot(ret_time, np.imag(rh), label='Imag')\n",
-    "plt.plot(ret_time,  np.abs(rh), label='Abs')\n",
-    "plt.title('Extrapolated Waveform, N=4')\n",
-    "plt.xlabel('$(t_{corr} - r^{*})/M$')\n",
-    "plt.ylabel('$rh^{(2,2)}$')\n",
-    "plt.legend()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rh_data.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
     "## Getting a GW Quantity at a Point on the Sphere\n",
     "\n",
     "Before getting started, you will need the following Python modules:\n",
     "* [quaternion](https://github.com/moble/quaternion)\n",
     "* [spherical_functions](https://github.com/moble/spherical_functions)\n",
     "\n",
-    "To compute the actual value of $rh$ and not just the mode weights, we need to perform the summation in Eq. (1), reproduced here for convenience:\n",
-    "$$ h(r,t,\\theta,\\phi) = \\sum_{\\ell} \\sum_{m=-\\ell}^{\\ell} h^{(\\ell,m)}(r,t)\\; {}_{-2}Y_{\\ell}^{m}(\\theta,\\phi)$$\n",
+    "To compute the actual value of $h$ and not just the mode weights, we need to perform the summation in Eq. (1), reproduced here for convenience:\n",
+    "$$ h(r,t,\\theta,\\phi) = \\frac{1}{r} \\sum_{\\ell} \\sum_{m=-\\ell}^{\\ell} h^{(\\ell,m)}(r,t)\\; {}_{-2}Y_{\\ell}^{m}(\\theta,\\phi)$$\n",
     "\n",
     "Unlike the mode weights, the value of $rh$ is a function of $(\\theta,\\phi)$ so we need to specify a point on the sphere at which to define the SWSHs. Let's define two functions to make our life easier first:"
    ]

--- a/get_sxs_public_metadata.py
+++ b/get_sxs_public_metadata.py
@@ -14,7 +14,7 @@ import sys
 
 def resolutions_for_simulation(sxs_id, zenodo_metadata):
     """Returns a list of the available resolutions for a given sxs_id
-    and zenodo metadata metadata"""
+    and zenodo metadata"""
     resolutions = []
     files = zenodo_metadata[sxs_id]['files']
     for file in files:


### PR DESCRIPTION
Instead of starting with the finite radius waveforms and spending time going into detail for them, we start with and only use the extrapolated waveforms. This should encourage people to only use the COM corrected and extrapolated waveforms.

(Also corrects a minor spelling error)